### PR TITLE
goreleaser で生成された dist を削除しない

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v1
         with:
           version: latest
-          args: release --snapshot --rm-dist
+          args: release --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
release にどの様にアーカイブされるか確認する為に、 --rm-dist
オプションを削除しました。