### PR TITLE
Update/goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v1
         with:
           version: latest
-          args: release --snapshot
+          args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: goreleaser
 
 on:
   push:
-    branches:
-      - master
+    tags:
+    - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   goreleaser:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,28 +1,29 @@
-# This is an example goreleaser.yaml file with some sane defaults.
-# Make sure to check the documentation at http://goreleaser.com
+project_name: typing-game-go
+
+env:
+  - GO111MODULE=on
 before:
   hooks:
-    # you may remove this if you don't use vgo
     - go mod tidy
-    # you may remove this if you don't need go generate
-    - go generate ./...
 builds:
-- env:
-  - CGO_ENABLED=0
+  - main: .
+    binary: typing-game-go
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
+      - -X main.Revision={{.ShortCommit}}
+    env:
+      - CGO_ENABLED=0
 archives:
-- replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
-checksum:
-  name_template: 'checksums.txt'
-snapshot:
-  name_template: "{{ .Tag }}-next"
-changelog:
-  sort: asc
-  filters:
-    exclude:
-    - '^docs:'
-    - '^test:'
+  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
+    replacements:
+      darwin: darwin
+      linux: linux
+      windows: windows
+      386: i386
+      amd64: x86_64
+    format_overrides:
+      - goos: windows
+        format: zip
+release:
+  prerelease: auto


### PR DESCRIPTION
.goreleaser.yml の修正
* build 時の設定更新
  - main パッケージディレクトリ指定
  - ldflags による version や short commit 埋め込み
  - CGO を無効化
* prerelease: auto
  - タグに関連するインジケータがある場合、本番用の準備ができていないとして、 -rc[0-9]+ を suffix に付与

GitHub Actions go releaser の修正
* --snapshot でなく、タグ付けした際をトリガーとした為、 --snapshot オプションを削除した。
代わりに、 dist の削除はやはりしときたいので --rm-dist を追加